### PR TITLE
Make message parsing configurable.

### DIFF
--- a/cranial/base.py
+++ b/cranial/base.py
@@ -2,8 +2,10 @@
 base classes for models
 """
 from abc import ABCMeta, abstractmethod
-import os
 from collections import OrderedDict
+import json
+import os
+
 from cranial.common import logger
 from cranial.re_iter import ReMap
 
@@ -151,6 +153,16 @@ class State(metaclass=ABCMeta):
         return NotImplemented
 
 
+class LegacyTroncParser():
+    def loads(msg):
+        parsed = json.loads(msg.split('\t')[-1])
+        return dict([(k, v) if len(v) > 1 else (k, v[0])
+            for k, v in parsed.items()])
+
+    def dumps(msg):
+        return json.dumps([msg['name'], msg['results']])
+
+
 class ModelBase(metaclass=ABCMeta):
     """A model that does not have a state, just implements a data transformation
     method.
@@ -170,6 +182,11 @@ class ModelBase(metaclass=ABCMeta):
     False
     """
     name = 'ModelBase'
+    # Set `encoding` to `False` for a model that handles binary messages.
+    encoding = 'utf-8'
+    parser = json
+    timer = False
+
     def __init__(self, **kwargs):
         self.proc_type = kwargs.pop('proc_type', None)
         self.n_proc = kwargs.pop('n_proc', 1)


### PR DESCRIPTION
Trying to clean-up the serving script, and make it more configurable.

Arguably, these configs should go in config.json rather than model.py. If someone wanted to fork this to do it that way instead, I'd likely accept a PR. This is just what I had time for right now. 

@amnezzia, @jmsteinw, 
You guys should look at this, because it will break your services when merged, if you update. I tired to make the fix very easy for you though; just set `Model.parser = cranial.base.LegacyTroncParser` in all your model.py's.